### PR TITLE
Symfony 3 compatibility

### DIFF
--- a/Tests/AbstractTestCase.php
+++ b/Tests/AbstractTestCase.php
@@ -38,7 +38,6 @@ class AbstractTestCase extends PHPUnit_Framework_TestCase
         $container->setParameter('kernel.cache_dir', sys_get_temp_dir() . '/linkify');
         $container->setParameter('kernel.bundles', array());
         $container->setParameter('kernel.root_dir', __DIR__ . '/Fixtures');
-        $container->set('service_container', $container);
 
         $container->registerExtension($extension);
         $extension->load($config, $container);

--- a/Tests/Twig/Extension/LinkifyTwigExtensionTest.php
+++ b/Tests/Twig/Extension/LinkifyTwigExtensionTest.php
@@ -36,8 +36,12 @@ class LinkifyTwigExtensionTest extends AbstractTestCase
 
         $filters = $extension->getFilters();
 
-        $this->assertArrayHasKey('linkify', $filters);
-        $this->assertInstanceOf('Twig_Filter_Method', $filters['linkify']);
+        
+        $linkifyFilters = array_filter($filters, function (\Twig_SimpleFilter $filter) {
+            return $filter->getName() === 'linkify';
+        });
+
+        $this->assertCount(1, $linkifyFilters);
     }
 
     public function testLinkify()

--- a/Twig/Extension/LinkifyTwigExtension.php
+++ b/Twig/Extension/LinkifyTwigExtension.php
@@ -12,7 +12,7 @@
 namespace Misd\LinkifyBundle\Twig\Extension;
 
 use Twig_Extension;
-use Twig_Filter_Method;
+use Twig_SimpleFilter;
 use Misd\LinkifyBundle\Helper\LinkifyHelper;
 
 /**
@@ -41,9 +41,9 @@ class LinkifyTwigExtension extends Twig_Extension
     public function getFilters()
     {
         return array(
-            'linkify' => new Twig_Filter_Method($this, 'linkify', array(
+            new Twig_SimpleFilter('linkify', array($this, 'linkify'), array(
                 'pre_escape' => 'html',
-                'is_safe' => array('html')
+                'is_safe'    => array('html')
             )),
         );
     }

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
     },
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": "~2.1",
+        "symfony/framework-bundle": "^2.3 || ^3.0",
         "misd/linkify": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",
-        "symfony/twig-bundle": "~2.1"
+        "symfony/twig-bundle": "^2.3.24 || ^3.0"
     },
     "conflict": {
         "phpunit/phpunit-mock-objects": "<2.2"


### PR DESCRIPTION
Use Twig_SimpleFilter to fix Symfony 3 compatibility issue. AFAICT that is the only required change.
