### PR TITLE
Allow symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,27 +2,40 @@ language: php
 
 sudo: false
 
+env:
+  global:
+    - SYMFONY_VERSION=""
+
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
 
 matrix:
-    allow_failures:
-        - php: hhvm
-    fast_finish: true
-    include:
-        - php: 5.3
-          env: dependencies=lowest
+  allow_failures:
+     - php: hhvm
+  fast_finish: true
+  include:
+    - php: 5.3
+      env: SYMFONY_VERSION="2.1.*"
+      dist: precise
+    - php: 5.5
+      env: SYMFONY_VERSION="3.0.*"
+    - php: 7.1
+      env: SYMFONY_VERSION="4.0.*"
 
 cache:
-    directories:
-      - $HOME/.composer/cache/files
+  directories:
+    - $HOME/.composer/cache/files
 
-install:
-  - if [ "$dependencies" = "lowest" ]; then composer update --prefer-lowest --no-interaction; else composer install --no-interaction; fi;
+before_install:
+  - phpenv config-rm xdebug.ini
+  - echo "memory_limit=-1" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony:$SYMFONY_VERSION; fi
+
+install: composer update --prefer-lowest --no-interaction
 
 script: ./vendor/bin/phpunit --coverage-text

--- a/Tests/AbstractTestCase.php
+++ b/Tests/AbstractTestCase.php
@@ -13,6 +13,7 @@ namespace Misd\LinkifyBundle\Tests;
 
 use Misd\LinkifyBundle\MisdLinkifyBundle;
 use PHPUnit_Framework_TestCase;
+use Symfony\Component\DependencyInjection\Compiler\ResolveChildDefinitionsPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass;
 use Symfony\Component\DependencyInjection\Compiler\ResolveParameterPlaceHoldersPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -44,7 +45,12 @@ class AbstractTestCase extends PHPUnit_Framework_TestCase
         $bundle->build($container);
 
         $container->getCompilerPassConfig()->setOptimizationPasses(
-            array(new ResolveParameterPlaceHoldersPass(), new ResolveDefinitionTemplatesPass())
+            array(
+                new ResolveParameterPlaceHoldersPass(),
+                class_exists('Symfony\Component\DependencyInjection\Compiler\ResolveDefinitionTemplatesPass')
+                    ? new ResolveDefinitionTemplatesPass()
+                    : new ResolveChildDefinitionsPass()
+            )
         );
         $container->getCompilerPassConfig()->setRemovingPasses(array());
         $container->compile();

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,13 @@
     },
     "require": {
         "php": "^5.3.3 || ^7.0",
-        "symfony/framework-bundle": "^2.1 || ^3.0",
+        "symfony/framework-bundle": "^2.1 || ^3.0 || ^4.0",
         "misd/linkify": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.0 || ^5.0",
-        "symfony/twig-bundle": "^2.1 || ^3.0"
+        "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "sebastian/version": ">=1.0.3",
+        "symfony/twig-bundle": "^2.1 || ^3.0 || ^4.0"
     },
     "conflict": {
         "phpunit/phpunit-mock-objects": "<2.2",


### PR DESCRIPTION
Hi,

This is a PR to allow symfony 4.

I have updated the travis-ci config to test multiple versions of symfony. I had to disable xdebug because of memory errors with composer.